### PR TITLE
fix:define-static-height

### DIFF
--- a/src/pages/Cart/styles.ts
+++ b/src/pages/Cart/styles.ts
@@ -23,7 +23,7 @@ export const Product = styled.View`
   padding: 15px 10px;
   border-radius: 5px;
   margin: 5px;
-  flex: 1;
+  height: 124px;
   flex-direction: row;
 `;
 


### PR DESCRIPTION
should avoid using flex: 1 on elements of a list. and avoid a bug that happens when you delete a product