### PR TITLE
fix: FlatList layout and typing

### DIFF
--- a/src/pages/Cart/styles.ts
+++ b/src/pages/Cart/styles.ts
@@ -14,7 +14,6 @@ export const ProductContainer = styled.View`
 `;
 
 export const ProductList = styled(FlatList)`
-  flex: 1;
   padding: 0 10px;
 `;
 

--- a/src/pages/Cart/styles.ts
+++ b/src/pages/Cart/styles.ts
@@ -1,6 +1,14 @@
 import styled from 'styled-components/native';
 import { FlatList } from 'react-native';
 
+interface Product {
+  id: string;
+  title: string;
+  image_url: string;
+  price: number;
+  quantity: number;
+}
+
 export const Container = styled.SafeAreaView`
   flex: 1;
   align-items: center;
@@ -13,7 +21,7 @@ export const ProductContainer = styled.View`
   flex-direction: row;
 `;
 
-export const ProductList = styled(FlatList)`
+export const ProductList = styled(FlatList as new () => FlatList<Product>)`
   padding: 0 10px;
 `;
 


### PR DESCRIPTION
Fix 1: Add a workaround on the styled FlatList, so that the component is able to infer the type of the list data as Product instead of 'unknown'.

Fix 2: Take `flex: 1` away to prevent layout issues when removing an item:

![gostack11](https://user-images.githubusercontent.com/15945802/82965140-ada25400-9f9d-11ea-8048-d5d48fe69d6b.png)
